### PR TITLE
BUG: fixed passing affine_transform when creating new instance of CompositeTransform

### DIFF
--- a/src/aspire/transforms.py
+++ b/src/aspire/transforms.py
@@ -332,6 +332,7 @@ class CompositeTransform(BaseTransform):
             prior_bounds=self.prior_bounds,
             bounded_to_unbounded=self.bounded_to_unbounded,
             bounded_transform=self.bounded_transform,
+            affine_transform=self.affine_transform,
             device=self.device,
             xp=xp or self.xp,
             eps=self.eps,


### PR DESCRIPTION
The `self.affine_transform` flag wasn't being passed when creating a new instance of `CompositeTransform`