### PR TITLE
BUG: set parameters when initializing the sampler

### DIFF
--- a/src/aspire/aspire.py
+++ b/src/aspire/aspire.py
@@ -354,6 +354,7 @@ class Aspire:
             xp=self.xp,
             dtype=self.dtype,
             preconditioning_transform=transform,
+            parameters=self.parameters,
             **kwargs,
         )
         return sampler


### PR DESCRIPTION
Specify `parameters` when initialising the sampler class.