### PR TITLE
ENH: improve array conversion

### DIFF
--- a/src/aspire/history.py
+++ b/src/aspire/history.py
@@ -103,6 +103,7 @@ class SMCHistory(History):
             for k, v in self.__dict__.items()
             if k not in exclude
         }
+        dictionary["__len_sample_history"] = len(self.sample_history)
         recursively_save_to_h5_file(h5_file, path, dictionary)
         for i, samples in enumerate(self.sample_history):
             samples.save(h5_file, path=f"{path}__sample_history/{i}")

--- a/src/aspire/history.py
+++ b/src/aspire/history.py
@@ -96,11 +96,15 @@ class SMCHistory(History):
             The path within the HDF5 file to save the history. Default is
             "smc_history".
         """
-        dictionary = copy.deepcopy(self.__dict__)
-        sample_history = dictionary.pop("sample_history", [])
-        dictionary["__len_sample_history"] = len(sample_history)
+        # Exclude sample_history from the main dictionary since it is saved separately
+        exclude = {"sample_history"}
+        dictionary = {
+            k: copy.deepcopy(v)
+            for k, v in self.__dict__.items()
+            if k not in exclude
+        }
         recursively_save_to_h5_file(h5_file, path, dictionary)
-        for i, samples in enumerate(sample_history):
+        for i, samples in enumerate(self.sample_history):
             samples.save(h5_file, path=f"{path}__sample_history/{i}")
 
     @classmethod

--- a/src/aspire/samplers/base.py
+++ b/src/aspire/samplers/base.py
@@ -6,7 +6,13 @@ from typing import Any, Callable
 from ..flows.base import Flow
 from ..samples import Samples
 from ..transforms import IdentityTransform
-from ..utils import AspireFile, asarray, dump_state, track_calls
+from ..utils import (
+    AspireFile,
+    asarray,
+    determine_backend_name,
+    dump_state,
+    track_calls,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +53,7 @@ class Sampler:
         self._log_prior = log_prior
         self.dims = dims
         self.xp = xp
+        self.backend_str = determine_backend_name(xp=self.xp)
         self.dtype = dtype
         self.parameters = parameters
         self.history = None

--- a/src/aspire/samplers/mcmc.py
+++ b/src/aspire/samplers/mcmc.py
@@ -2,6 +2,7 @@ import logging
 from typing import Callable
 
 import numpy as np
+from orng import ArrayRNG
 
 from ..samples import MCMCSamples, Samples, to_numpy
 from ..utils import AspireFile, track_calls
@@ -43,7 +44,7 @@ class MCMCSampler(Sampler):
             parameters,
             preconditioning_transform,
         )
-        self.rng = rng or np.random.default_rng()
+        self.rng = rng or ArrayRNG(backend=self.backend_str)
 
     def draw_initial_samples(self, n_samples: int) -> Samples:
         """Draw initial samples from the prior flow."""
@@ -96,7 +97,7 @@ class MCMCSampler(Sampler):
             + samples.log_prior
             + samples.array_to_namespace(log_abs_det_jacobian)
         )
-        return to_numpy(log_prob).flatten()
+        return log_prob.flatten()
 
     def default_mcmc_chain_file_checkpoint_callback(
         self, file_path: str | None
@@ -164,7 +165,16 @@ class MCMCSampler(Sampler):
         checkpoint_callback(state)
 
 
-class Emcee(MCMCSampler):
+class NumpyMCMCSampler(MCMCSampler):
+    """MCMCSampler that maps samples and log probabilities to NumPy arrays for
+    compatibility with numpy-only samplers
+    """
+
+    def log_prob(self, z):
+        return to_numpy(super().log_prob(z))
+
+
+class Emcee(NumpyMCMCSampler):
     @track_calls
     def sample(
         self,
@@ -246,12 +256,13 @@ class MiniPCN(MCMCSampler):
         checkpoint_file_path: str | None = None,
     ):
         from minipcn import Sampler
+        from orng import ArrayRNG
 
-        rng = rng or self.rng or np.random.default_rng()
+        rng = rng or self.rng or ArrayRNG(backend=self.backend_str)
         n_walkers = n_walkers or n_samples
         p0 = self.draw_initial_samples(n_walkers).x
 
-        z0 = to_numpy(self.preconditioning_transform.fit(p0))
+        z0 = self.preconditioning_transform.fit(p0)
 
         self.sampler = Sampler(
             log_prob_fn=self.log_prob,
@@ -259,6 +270,7 @@ class MiniPCN(MCMCSampler):
             rng=rng,
             dims=self.dims,
             target_acceptance_rate=target_acceptance_rate,
+            xp=self.xp,
         )
 
         chain, history = self.sampler.sample(z0, n_steps=n_steps)

--- a/src/aspire/samplers/smc/base.py
+++ b/src/aspire/samplers/smc/base.py
@@ -12,6 +12,7 @@ from ...utils import (
     asarray,
     determine_backend_name,
     effective_sample_size,
+    to_numpy,
     track_calls,
     update_at_indices,
 )
@@ -518,6 +519,9 @@ class SMCSampler(MCMCSampler):
 
 
 class NumpySMCSampler(SMCSampler):
+    """SMCSampler that maps samples and log probabilities to NumPy arrays for
+    compatibility with numpy-only samplers"""
+
     def __init__(
         self,
         log_likelihood,
@@ -543,3 +547,7 @@ class NumpySMCSampler(SMCSampler):
             parameters=parameters,
             preconditioning_transform=preconditioning_transform,
         )
+
+    def log_prob(self, z, beta=None):
+        log_prob = super().log_prob(z, beta=beta)
+        return to_numpy(log_prob)

--- a/src/aspire/samplers/smc/base.py
+++ b/src/aspire/samplers/smc/base.py
@@ -293,7 +293,7 @@ class SMCSampler(MCMCSampler):
         self.fit_preconditioning_transform(samples.x)
 
         if store_sample_history:
-            self.history.sample_history.append(samples)
+            self.history.sample_history.append(samples.to_numpy())
 
         if self.xp.isnan(samples.log_q).any():
             raise ValueError("Log proposal contains NaN values")

--- a/src/aspire/samplers/smc/base.py
+++ b/src/aspire/samplers/smc/base.py
@@ -481,7 +481,7 @@ class SMCSampler(MCMCSampler):
     ) -> dict:
         """Prepare a serializable checkpoint payload for the sampler state."""
         return super().build_checkpoint_state(
-            samples,
+            samples.to_numpy(),
             iteration,
             meta={"beta": beta},
         )

--- a/src/aspire/samplers/smc/base.py
+++ b/src/aspire/samplers/smc/base.py
@@ -378,11 +378,11 @@ class SMCSampler(MCMCSampler):
                     beta_tolerance=beta_tolerance,
                 )
                 self.history.eff_target.append(
-                    self.current_target_efficiency(beta)
+                    float(self.current_target_efficiency(beta))
                 )
 
                 logger.info(f"it {iterations} - beta: {beta}")
-                self.history.beta.append(beta)
+                self.history.beta.append(float(beta))
 
                 ess = effective_sample_size(samples.log_weights(beta))
                 eff = ess / len(samples)
@@ -390,20 +390,22 @@ class SMCSampler(MCMCSampler):
                     logger.warning(
                         f"it {iterations} - Low sample efficiency: {eff:.2f}"
                     )
-                self.history.ess.append(ess)
+                self.history.ess.append(float(ess))
                 logger.info(
                     f"it {iterations} - ESS: {ess:.1f} ({eff:.2f} efficiency)"
                 )
                 self.history.ess_target.append(
-                    effective_sample_size(samples.log_weights(1.0))
+                    float(effective_sample_size(samples.log_weights(1.0)))
                 )
 
                 log_evidence_ratio = samples.log_evidence_ratio(beta)
                 log_evidence_ratio_var = samples.log_evidence_ratio_variance(
                     beta
                 )
-                self.history.log_norm_ratio.append(log_evidence_ratio)
-                self.history.log_norm_ratio_var.append(log_evidence_ratio_var)
+                self.history.log_norm_ratio.append(float(log_evidence_ratio))
+                self.history.log_norm_ratio_var.append(
+                    float(log_evidence_ratio_var)
+                )
                 logger.info(
                     f"it {iterations} - Log evidence ratio: {log_evidence_ratio:.2f} +/- {np.sqrt(log_evidence_ratio_var):.2f}"
                 )
@@ -412,7 +414,7 @@ class SMCSampler(MCMCSampler):
 
                 samples = self.mutate(samples, beta)
                 if store_sample_history:
-                    self.history.sample_history.append(samples)
+                    self.history.sample_history.append(samples.to_numpy())
                 maybe_checkpoint()
                 if beta == 1.0 or (
                     max_n_steps is not None and iterations >= max_n_steps

--- a/src/aspire/samplers/smc/minipcn.py
+++ b/src/aspire/samplers/smc/minipcn.py
@@ -6,7 +6,6 @@ import numpy as np
 from ...samples import SMCSamples
 from ...utils import (
     asarray,
-    determine_backend_name,
     track_calls,
 )
 from .base import SMCSampler
@@ -48,7 +47,6 @@ class MiniPCNSMC(SMCSampler):
         self.sampler_kwargs.setdefault("target_acceptance_rate", 0.234)
         self.sampler_kwargs.setdefault("step_fn", "tpcn")
         self.sampler_kwargs.setdefault("verbose", True)
-        self.backend_str = determine_backend_name(xp=self.xp)
         self.rng = rng or self.rng or ArrayRNG(backend=self.backend_str)
         return super().sample(
             n_samples,

--- a/src/aspire/samples.py
+++ b/src/aspire/samples.py
@@ -24,7 +24,6 @@ from .utils import (
     logsumexp,
     recursively_save_to_h5_file,
     resolve_dtype,
-    safe_to_device,
     to_numpy,
 )
 
@@ -138,14 +137,7 @@ class BaseSamples:
 
     def array_to_namespace(self, x, dtype=None):
         """Convert an array to the same namespace as the samples"""
-        kwargs = {}
-        if dtype is not None:
-            kwargs["dtype"] = resolve_dtype(dtype, self.xp)
-        else:
-            kwargs["dtype"] = self.dtype
-        x = asarray(x, self.xp, **kwargs)
-        x = safe_to_device(x, self.device, self.xp)
-        return x
+        return asarray(x, self.xp, dtype=dtype, device=self.device)
 
     def to_dict(self, flat: bool = True, copy: bool = True):
         """Convert the samples to a dictionary.

--- a/src/aspire/utils.py
+++ b/src/aspire/utils.py
@@ -284,16 +284,25 @@ def asarray(x, xp: Any = None, dtype: Any | None = None, **kwargs) -> Array:
     kwargs : dict
         Additional keyword arguments to pass to xp.asarray.
     """
+    if dtype is not None:
+        kwargs["dtype"] = resolve_dtype(dtype, xp=xp)
     # Handle DLPack conversion from JAX to PyTorch to avoid shape issues when
     # passing JAX arrays directly to torch.asarray.
     if is_jax_array(x) and is_torch_namespace(xp):
         tensor = xp.utils.dlpack.from_dlpack(x)
         if dtype is not None:
-            tensor = tensor.to(resolve_dtype(dtype, xp=xp))
+            tensor = tensor.to(kwargs["dtype"])
         return tensor
 
-    if dtype is not None:
-        kwargs["dtype"] = resolve_dtype(dtype, xp=xp)
+    # Handle DLPack conversion from PyTorch to JAX to avoid issues with
+    # detaching tensors
+    if is_torch_array(x) and is_jax_namespace(xp):
+        import jax.dlpack
+
+        arr = jax.dlpack.from_dlpack(x.detach())
+        if dtype is not None:
+            arr = arr.astype(kwargs["dtype"])
+        return arr
 
     if is_numpy_namespace(xp):
         return to_numpy(x, **kwargs)

--- a/src/aspire/utils.py
+++ b/src/aspire/utils.py
@@ -261,9 +261,11 @@ def to_numpy(x: Array, **kwargs) -> np.ndarray:
     kwargs : dict
         Additional keyword arguments to pass to numpy.asarray.
     """
+    if is_torch_array(x):
+        x = x.detach()
     try:
         return np.asarray(to_device(x, "cpu"), **kwargs)
-    except (ValueError, NotImplementedError):
+    except (ValueError, NotImplementedError, AttributeError):
         return np.asarray(x, **kwargs)
 
 
@@ -292,6 +294,9 @@ def asarray(x, xp: Any = None, dtype: Any | None = None, **kwargs) -> Array:
 
     if dtype is not None:
         kwargs["dtype"] = resolve_dtype(dtype, xp=xp)
+
+    if is_numpy_namespace(xp):
+        return to_numpy(x, **kwargs)
     return xp.asarray(x, **kwargs)
 
 

--- a/tests/test_samplers/test_mcmc/test_checkpointing.py
+++ b/tests/test_samplers/test_mcmc/test_checkpointing.py
@@ -91,8 +91,9 @@ def test_minipcn_mcmc_saves_chain_checkpoint(monkeypatch, tmp_path):
             rng,
             dims,
             target_acceptance_rate,
+            xp,
         ):
-            _ = (log_prob_fn, step_fn, rng, dims, target_acceptance_rate)
+            _ = (log_prob_fn, step_fn, rng, dims, target_acceptance_rate, xp)
 
         def sample(self, z0, n_steps=100):
             z0 = np.asarray(z0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,8 +6,10 @@ import array_api_compat.torch as torch_xp
 import h5py
 import jax.numpy as jnp
 import pytest
+from array_api_compat import array_namespace
 
 from aspire.utils import (
+    asarray,
     configure_logger,
     convert_dtype,
     dump_state,
@@ -82,6 +84,40 @@ def test_resolve_dtype_passes_through_torch_dtype():
 def test_resolve_dtype_errors_on_unknown():
     with pytest.raises(ValueError):
         resolve_dtype("not_a_real_dtype", np_xp)
+
+
+@pytest.mark.parametrize(
+    ("xp_input", "xp_target"),
+    [
+        (np_xp, torch_xp),
+        (np_xp, jnp),
+        (torch_xp, jnp),
+        (torch_xp, np_xp),
+        (jnp, np_xp),
+        (jnp, torch_xp),
+    ],
+)
+@pytest.mark.parametrize("dtype", [None, "float32", "float64"])
+def test_asarray(xp_input, xp_target, dtype):
+    arr = xp_input.asarray([1, 2, 3])
+    converted = asarray(arr, xp_target, dtype=dtype)
+    namespace = array_namespace(converted)
+    assert namespace is xp_target
+    assert np_xp.allclose(converted, [1, 2, 3])
+    assert (
+        converted.dtype == resolve_dtype(dtype, xp=namespace)
+        if dtype
+        else arr.dtype
+    )
+
+
+@pytest.mark.parametrize("xp_target", [np_xp, jnp])
+def test_asarray_torch_grad(xp_target):
+    arr = torch_xp.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    converted = asarray(arr, xp_target)
+    namespace = array_namespace(converted)
+    assert namespace is xp_target
+    assert np_xp.allclose(converted, [1.0, 2.0, 3.0])
 
 
 def test_dump_state_round_trip(tmp_path):


### PR DESCRIPTION
Recent changes to torch highlighted several places where tensors were being copied incorrectly, causing test failures.

I've improved the functions for converting between arrays and fixed several places where things were previously failing silently.