### PR TITLE
MAINT: fix version attribute

### DIFF
--- a/src/aspire/__init__.py
+++ b/src/aspire/__init__.py
@@ -10,7 +10,7 @@ from .samples import Samples
 from .utils import enable_scipy_array_api
 
 try:
-    __version__ = version("aspire")
+    __version__ = version("aspire-inference")
 except PackageNotFoundError:
     __version__ = "unknown"
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,4 @@
+def test_version():
+    from aspire import __version__
+
+    assert __version__ != "unknown"


### PR DESCRIPTION
`aspire.__version__` was always none since the metadata name is `aspire-inference`